### PR TITLE
ci: migrate from Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,24 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18, 20, 22, 24]
+        node-version:
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          - 11
+          - 12
+          - 13
+          - 14
+          - 15
+          - 16
+          - 18
+          - 20
+          - 22
+          - 24
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [master, v1.5-dev]
+  pull_request:
+    branches: [master, v1.5-dev]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18, 20, 22, 24]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,8 @@ on:
     branches: [master, v1.5-dev]
 
 jobs:
-  test:
+  linux:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version:
@@ -26,6 +25,33 @@ jobs:
           - 14
           - 15
           - 16
+          - 18
+          - 20
+          - 22
+          - 24
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+  macos:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        node-version:
           - 18
           - 20
           - 22


### PR DESCRIPTION
## Summary

Replace the legacy `.travis.yml` with GitHub Actions CI.

## Changes

- New `ci.yml` workflow runs on push/PR to `master` and `v1.5-dev`
- Matrix: Node.js 4 / 5 / 6 / 7 / 8 / 9 / 10 / 11 / 12 / 13 / 14 / 15 / 16 / 18 / 20 / 22 / 24
- Steps: checkout → setup-node → npm install → build → test

## Motivation

Travis CI no longer offers free CI for open-source projects. GitHub Actions is the standard now. The new matrix covers the project's `engines: >=4.4.0` range and extends to current LTS releases.

## Testing

```
5 passing (9ms)
```
