### PR TITLE
test: add deflate stream integrity tests for multi-block images

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -108,5 +108,77 @@ describe('PNGlib', () => {
       should.equal(buf.readUInt32BE(16), 256);
       should.equal(buf.readUInt32BE(20), 257);
     });
+
+    describe('deflate stream integrity', () => {
+      const zlib = require('zlib');
+
+      function extractIDAT(buf) {
+        let off = 8, chunks = [];
+        while (off < buf.length) {
+          let len = buf.readUInt32BE(off);
+          if (buf.slice(off+4, off+8).toString() === 'IDAT')
+            chunks.push(buf.slice(off+8, off+8+len));
+          off += 12 + len;
+        }
+        return Buffer.concat(chunks);
+      }
+
+      function testDeflate(w, h) {
+        let png = new PNGlib(w, h, undefined, 'white');
+        for (let y = 0; y < h; y++)
+          for (let x = 0; x < w; x++)
+            png.setPixel(x, y, 'black');
+        let idat = extractIDAT(png.getBuffer());
+        return zlib.inflateSync(idat);
+      }
+
+      // Boundary: exactly 1 block
+      it('should decompress 254×257 (pix_size = 65535, single block boundary).', () => {
+        let out = testDeflate(254, 257);
+        should.equal(out.length, 257 * (254 + 1));
+      });
+
+      // Boundary: just under 1 block
+      it('should decompress 255×255 (pix_size < 65535).', () => {
+        let out = testDeflate(255, 255);
+        should.equal(out.length, 255 * (255 + 1));
+      });
+
+      // Boundary: exactly 1 block (different dims)
+      it('should decompress 256×255 (pix_size = 65535).', () => {
+        let out = testDeflate(256, 255);
+        should.equal(out.length, 255 * (256 + 1));
+      });
+
+      // Boundary: 2 blocks
+      it('should decompress 256×256 (pix_size = 65792, 2 blocks).', () => {
+        let out = testDeflate(256, 256);
+        should.equal(out.length, 256 * (256 + 1));
+      });
+
+      // Medium
+      it('should decompress 300×300 (2 blocks).', () => {
+        let out = testDeflate(300, 300);
+        should.equal(out.length, 300 * (300 + 1));
+      });
+
+      // 3 blocks
+      it('should decompress 400×400 (3 blocks).', () => {
+        let out = testDeflate(400, 400);
+        should.equal(out.length, 400 * (400 + 1));
+      });
+
+      // Many blocks
+      it('should decompress 1000×1000 (16 blocks).', () => {
+        let out = testDeflate(1000, 1000);
+        should.equal(out.length, 1000 * (1000 + 1));
+      });
+
+      // Odd dimensions
+      it('should decompress 333×777 (odd/prime).', () => {
+        let out = testDeflate(333, 777);
+        should.equal(out.length, 777 * (333 + 1));
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

Add deflate stream integrity tests using `zlib.inflateSync` to directly validate that multi-block PNG images produce valid deflate streams with correct adler32 checksums.

## What's tested

| Image | Blocks | Purpose |
|-------|--------|---------|
| 254×257 | 1 (edge) | pix_size exactly = 65535 |
| 255×255 | 1 | pix_size < 65535 |
| 256×255 | 1 (edge) | pix_size exactly = 65535 |
| 256×256 | 2 | pix_size = 65792, just over boundary |
| 300×300 | 2 | normal multi-block case |
| 400×400 | 3 | three deflate blocks |
| 1000×1000 | 16 | many blocks |
| 333×777 | varies | odd/prime dimensions |

The tests pass the raw IDAT chunk to `zlib.inflateSync` which will throw if the deflate structure or adler32 is corrupted — catching regressions that reference-image comparisons alone might miss.

## Testing

```
15 passing (77ms)
```
