### PR TITLE
fix: clamp array color values to 0-255 range

### DIFF
--- a/lib/color.js
+++ b/lib/color.js
@@ -41,7 +41,11 @@ function getRGBA(args) {
     return CACHE.get(color);
   }
   if (red >= 0 && green >= 0 && blue >= 0) {
-    var res = [red, green, blue, alpha >= 0 ? alpha : 255];
+    var clamp = function clamp(v) {
+      return v > 255 ? 255 : v;
+    };
+
+    var res = [clamp(red), clamp(green), clamp(blue), alpha >= 0 ? alpha : 255];
     CACHE.set(color, res);
     return res;
   }

--- a/src/color.js
+++ b/src/color.js
@@ -21,7 +21,8 @@ export function getRGBA(args) {
     return CACHE.get(color);
   }
   if (red >= 0 && green >= 0 && blue >= 0 ) {
-    let res = [red, green, blue, alpha >= 0 ? alpha : 255];
+    function clamp(v) { return v > 255 ? 255 : v; }
+    let res = [clamp(red), clamp(green), clamp(blue), alpha >= 0 ? alpha : 255];
     CACHE.set(color, res);
     return res;
   }

--- a/test/test.js
+++ b/test/test.js
@@ -24,6 +24,21 @@ describe('PNGlib', () => {
       should.equal(png.getBase64(),
         'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAMAAAAoyzS7AAAAGFBMVEUAAAD/AAAAAAAAAAAAAAAAAAAAAAAAAAAAXHRiAAAACHRSTlMA/wAAAAAAACXRGJEAAAANSURBVHjaAQIA/f8AAQADAAL2gI4NAAAAAElFTkSuQmCC');
     });
+
+    it('should clamp out-of-range array color values (issue #19).', () => {
+      let png = new PNGlib(1, 1);
+      // Values above 255 should be clamped down
+      let idx = png.color([300, 128, 400, 255]);
+      let plteOff = png.plte_offs + 8 + 3 * idx;
+      should.equal(png.buffer[plteOff], 255);     // red clamped to 255
+      should.equal(png.buffer[plteOff + 1], 128);  // green unchanged
+      should.equal(png.buffer[plteOff + 2], 255);  // blue clamped to 255
+    });
+
+    it('should reject negative array color values.', () => {
+      let png = new PNGlib(1, 1);
+      should.throws(() => png.color([-50, 0, 0, 255]), /Invalid color/);
+    });
   });
 
   describe('#draw.', () => {


### PR DESCRIPTION
## Summary

Fix array color values not being clamped to the valid 0-255 range.

## Problem

`getRGBA()` has two paths:
- **String path**: goes through `rgba.js` which calls `clamp()` ✓
- **Array path**: `[R, G, B, A]` is used as-is without clamping

This means `[300, 0, 0, 255]` writes value 300 into the PLTE chunk, producing corrupted color data.

## Fix

Add a `clamp(v)` call for R, G, B in the array path that caps values > 255.

## Tests

- Verifies [300, 128, 400] → [255, 128, 255]
- Verifies negative values still throw

Closes #19.