### PR TITLE
fix: validate PNG dimensions in constructor

### DIFF
--- a/lib/pnglib.js
+++ b/lib/pnglib.js
@@ -24,6 +24,9 @@ module.exports = function () {
   function PNGlib(w, h, d, bg) {
     _classCallCheck(this, PNGlib);
 
+    if (typeof w !== 'number' || typeof h !== 'number' || w < 1 || h < 1) {
+      throw new Error('Invalid PNG dimensions: width and height must be positive integers');
+    }
     this.width = w;
     this.height = h;
     this.depth = d || 8;

--- a/src/pnglib.js
+++ b/src/pnglib.js
@@ -6,6 +6,9 @@ import * as color from './color';
 
 module.exports = class PNGlib {
   constructor (w, h, d, bg) {
+    if (typeof w !== 'number' || typeof h !== 'number' || w < 1 || h < 1) {
+      throw new Error('Invalid PNG dimensions: width and height must be positive integers');
+    }
     this.width   = w;
     this.height  = h;
     this.depth   = d || 8;

--- a/test/test.js
+++ b/test/test.js
@@ -26,6 +26,16 @@ describe('PNGlib', () => {
     });
   });
 
+  describe('constructor', () => {
+    it('should reject invalid dimensions (issue #20).', () => {
+      should.throws(() => new PNGlib(0, 1), /Invalid PNG dimensions/);
+      should.throws(() => new PNGlib(1, 0), /Invalid PNG dimensions/);
+      should.throws(() => new PNGlib(0, 0), /Invalid PNG dimensions/);
+      should.throws(() => new PNGlib(-1, 1), /Invalid PNG dimensions/);
+      should.throws(() => new PNGlib('a', 1), /Invalid PNG dimensions/);
+    });
+  });
+
   describe('#draw.', () => {
     it('should draw a line', () => {
       let png = new PNGlib(100, 40);


### PR DESCRIPTION
## Summary

Guard against zero/negative dimensions in `PNGlib` constructor.

## Problem

`new PNGlib(0, 1)`, `new PNGlib(1, 0)`, etc. succeed but produce
an invalid PNG that fails zlib decompression.

## Fix

Validate `w > 0 && h > 0` (and typeof number) at the start of
the constructor, throwing a descriptive error.

Closes #20.