### PR TITLE
docs: restructure README and type definitions for AI agent readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,104 +1,164 @@
 # node-pnglib [![NPM Version](https://badge.fury.io/js/node-pnglib.svg)](http://badge.fury.io/js/node-pnglib) [![CI](https://github.com/Lellansin/node-pnglib/actions/workflows/ci.yml/badge.svg)](https://github.com/Lellansin/node-pnglib/actions)
 
-Pure Javascript lib for generate PNG, Node.js version for [PNGlib](http://www.xarg.org/2010/03/generate-client-side-png-files-using-javascript/).
+Pure JavaScript PNG encoder for Node.js. Port of [PNGlib](http://www.xarg.org/2010/03/generate-client-side-png-files-using-javascript/).
+
+Zero runtime dependencies. Generates indexed-color (palette) PNGs with no external tooling.
+
+---
+
+## Compatibility
+
+| Platform | Node.js versions | Status |
+|----------|-----------------|--------|
+| **Linux** | 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 20, 22, 24 | ✅ CI-passed |
+| **macOS** | 18, 20, 22, 24 | ✅ CI-passed |
+
+- Engine requirement: `>=4.4.0`
+- No native dependencies — works on any platform Node.js runs on
+- Tested across 17 Node.js major versions on Linux and 4 on macOS
+- Pure JS with no external runtime deps (only `color-name` for string parsing)
+
+---
 
 ## Installation
 
-```
+```sh
 npm install node-pnglib
 ```
 
-## Example
+---
 
-**Test it with http server:**
+## Quick Start
 
-```javascript
-const http = require('http');
+**Minimal 1×1 red pixel:**
+
+```js
 const PNGlib = require('node-pnglib');
-
-http.createServer(function (req, res) {
-  if(req.url == '/favicon.ico') return res.end('');
-
-  // width 100, height 40
-  let png = new PNGlib(100, 40);
-
-  // from (0, 20)
-  let lineIndex = png.index(0, 20);
-  for (let i = 0; i < 100; i++) {
-    // draw a line to (0, 75)
-    png.buffer[lineIndex + i] = png.color('blue');
-  }
-
-  res.setHeader('Content-Type', 'image/png');
-  res.end(png.getBuffer());
-}).listen(3001);
+const png = new PNGlib(1, 1);
+png.buffer[png.index(0, 0)] = png.color('red');
+require('fs').writeFileSync('out.png', png.getBuffer());
 ```
 
-Output:
+**300×300 blue square (multi-block stress test):**
 
-![line](/example/line.png)
-
-**Test with file:**
-
-```javascript
-const fs = require('fs');
+```js
 const PNGlib = require('node-pnglib');
-
-let png = new PNGlib(150, 150);
-for (let i = 20; i < 100; i++) {
-  for (let j = 20; j < 100; j++) {
-    png.setPixel(i + 10, j + 25, '#cc0044');
-    png.setPixel(i + 20, j + 10, '#0044cc');
-    png.setPixel(i + 30, j, '#00cc44');
-  }
-}
-
-fs.writeFileSync('./block.png', png.getBuffer());
+const png = new PNGlib(300, 300, undefined, 'white');
+for (let y = 0; y < 300; y++)
+  for (let x = 0; x < 300; x++)
+    png.setPixel(x, y, 'blue');
+require('fs').writeFileSync('blue.png', png.getBuffer());
 ```
 
-Output:
+---
 
-![line](/example/block.png)
+## API Reference
 
-**Let's try to draw waves:**
+### `new PNGlib(width, height, depth?, backgroundColor?)`
 
-```javascript
-const http = require('http');
-const PNGlib = require('node-pnglib');
+Creates a new PNG canvas.
 
-http.createServer(function (req, res) {
-  if(req.url == '/favicon.ico') return res.end('');
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `width` | `number` | — | Width in pixels (must be ≥ 1) |
+| `height` | `number` | — | Height in pixels (must be ≥ 1) |
+| `depth` | `number` | `8` | Color palette depth (max colors = 2^depth) |
+| `backgroundColor` | `ColorArg` | `[0, 0, 0, 0]` | Transparent black by default |
 
-  let png = new PNGlib(100, 40);
-  for (let i = 0, num = 100 / 10; i <= num; i += .01) {
-    let x = i * 10;
-    let y = Math.sin(i) * 10 + 20;
-    png.setPixel(x, (y - 10), '#0000FF');
-    png.setPixel(x, (y), '#FF0000');
-    png.setPixel(x, (y + 10), 'rgb(0,255,0)');
-  }
-  res.setHeader('Content-Type', 'image/png');
-  res.end(png.getBuffer());
-}).listen(3001);
+**Throws** if `width < 1` or `height < 1` or types are not numbers.
+
+### `png.index(x, y) → number`
+
+Returns the buffer index for a pixel position.
+
+- `x`: column (-1 = filter byte for the row)
+- `y`: row
+- Internal use typically; exposed for direct buffer manipulation.
+
+### `png.color(colorArg) → number`
+
+Resolves a color to a palette index. Adds the color to the palette if unseen.
+
+| Input format | Examples |
+|-------------|----------|
+| `[R, G, B, A]` | `[255, 0, 0, 255]` (values ≥ 0, clamped to 255) |
+| Named color | `'red'`, `'blue'`, `'transparent'` |
+| Hex | `'#ff0000'`, `'#f00'`, `'#ff000080'` |
+| rgb/rgba | `'rgb(255,0,0)'`, `'rgba(255,0,0,0.5)'` |
+| hsl/hsla percentages | `'hsl(0,100%,50%)'` |
+
+**Throws** if the color string is invalid or if R/G/B is negative.
+
+### `png.setPixel(x, y, colorArg)`
+
+Sets a pixel. Silently ignores out-of-bounds coordinates.
+
+### `png.setBgColor(colorArg) → number`
+
+Sets the background color (palette index 0). Overrides the default transparent black.
+
+### `png.getBuffer() → Buffer`
+
+Returns the complete PNG as a `Buffer` (ready to write to disk or send over HTTP).
+
+### `png.getBase64() → string`
+
+Returns the PNG as a Base64-encoded string.
+
+### `png.deflate() → Buffer`
+
+Same as `getBuffer()` — computes CRC32 and adler32 checksums, finalizes the PNG.
+
+---
+
+## Color Formats
+
+All color inputs support these formats — strings are cached internally:
+
+```js
+png.color([255, 0, 0, 255]);         // Array RGBA (clamped to [0, 255])
+png.color('red');                     // Named color
+png.color('#ff0000');                  // Hex 6-digit
+png.color('#f00');                     // Hex 3-digit
+png.color('#ff000080');               // Hex 8-digit (with alpha)
+png.color('rgb(255, 0, 0)');          // rgb()
+png.color('rgba(255, 0, 0, 0.5)');    // rgba()
+png.color('hsl(0, 100%, 50%)');       // hsl()
+png.color('hsla(0, 100%, 50%, 0.5)');// hsla()
+png.color('transparent');             // [0, 0, 0, 0]
 ```
 
-Output:
+---
 
-![line](/example/wave.png)
+## Internal Architecture
 
-# Benchmark
+node-pnglib constructs the PNG binary manually:
+
+1. **Header**: PNG signature + IHDR chunk
+2. **Palette**: PLTE chunk + tRNS transparency chunk
+3. **Pixel data**: IDAT chunk containing raw DEFLATE stored blocks (no compression level)
+4. **Footer**: IEND chunk
+
+The image data uses **row filter byte 0** (None) for every row. When the pixel data exceeds 65,535 bytes, it's split across multiple DEFLATE stored blocks with automatic adler32 and CRC32 checksums.
+
+---
+
+## Benchmark
 
 ```
-# Simple line
+# Simple line (100×40)
 
-pnglib x 1,021 ops/sec ±3.37% (76 runs sampled)
-pnglib-es6 x 3,293 ops/sec ±4.79% (79 runs sampled)
-node-pnglib x 17,027 ops/sec ±0.93% (87 runs sampled)
-Fastest is node-pnglib
+pnglib       x   1,021 ops/sec ±3.37%
+pnglib-es6   x   3,293 ops/sec ±4.79%
+node-pnglib  x  17,027 ops/sec ±0.93%   ← fastest
 
-node v8.1.1
-MacBook Pro (Retina, 13-inch, Early 2015)
-2.7 GHz Intel Core i5
+node v8.1.1 · MacBook Pro (Retina, 13-inch, Early 2015) · 2.7 GHz Intel Core i5
 ```
 
-It's faster than similar libraries. you can go to [here](https://github.com/Lellansin/node-pnglib/blob/master/bench/) for more benchmark infomation.
+Full benchmarks at [bench/](https://github.com/Lellansin/node-pnglib/blob/master/bench/).
+
+---
+
+## License
+
+BSD-2-Clause

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,36 +1,72 @@
-declare const Buffer
+/// <reference types="node" />
 
 type ColorString = string
-type ColorArr = number[]
-type RGBA = ColorString | ColorArr
+type ColorArray = [number, number, number, number?]
+type ColorArg = ColorString | ColorArray
 
 declare class NodePnglib {
+    /**
+     * Creates a new PNG canvas.
+     * @param width  Width in pixels (must be >= 1)
+     * @param height Height in pixels (must be >= 1)
+     * @param depth  Color palette depth, default 8 (max 2^depth colors)
+     * @param backgroundColor Default [0,0,0,0] (transparent black)
+     * @throws if width < 1 or height < 1
+     */
     constructor(
         width: number,
         height: number,
-        /** Color depth of the png, default to 8. */
         depth?: number,
-        /** For example: [1, 1, 1, 1], 'blue', 'transparent' or 'rgba(1, 1, 1, 1)', default to [0, 0, 0, 0]. */
-        backgroundColor?: RGBA
+        backgroundColor?: ColorArg
     )
 
+    /** Width in pixels. */
+    readonly width: number
+    /** Height in pixels. */
+    readonly height: number
+    /** Color depth. */
+    readonly depth: number
+    /** Raw internal buffer (for direct manipulation). */
+    readonly buffer: Buffer
+    /** Number of colors in the palette. */
+    readonly pindex: number
+
+    /**
+     * Returns the buffer index for pixel (x, y).
+     * Pass x=-1 to get the row filter byte.
+     */
     index(x: number, y: number): number
 
-    color(rgba: RGBA)
+    /**
+     * Resolves a color to a palette index.
+     * Adds the color to the palette if not yet seen.
+     * @throws if the color string is invalid
+     */
+    color(rgba: ColorArg): number
 
-    setBgColor(rgba: RGBA): number
+    /**
+     * Sets the background color (palette index 0).
+     * @returns the palette index (always 0)
+     */
+    setBgColor(rgba: ColorArg): number
 
-    setPixel(x: number, y: number, rgba: RGBA): void
+    /**
+     * Sets a pixel. Out-of-bounds coordinates are silently ignored.
+     */
+    setPixel(x: number, y: number, rgba: ColorArg): void
 
+    /** Returns the PNG as a Base64-encoded string. */
     getBase64(): string
 
+    /** Returns the complete PNG as a Buffer. */
     getBuffer(): Buffer
 
+    /** Finalizes and returns the PNG buffer (alias for getBuffer). */
     deflate(): Buffer
 }
 
 declare namespace NodePnglib {
-    export type Color = RGBA
+    export type Color = ColorArg
 }
 
 export = NodePnglib


### PR DESCRIPTION
## Summary

Rewrite README and TypeScript definitions for clarity, AI agent readability, and developer experience.

## README changes

- **Compatibility matrix**: platform × Node version table at the top (Linux v4-v24, macOS v18+)
- **Structured API reference**: table with param types, defaults, descriptions, and throw conditions
- **Comprehensive color formats**: complete reference table showing every supported format with examples
- **Internal architecture section**: explains the PNG binary structure (IHDR → PLTE → IDAT → IEND)
- **Quick start**: minimal 1×1 example + 300×300 multi-block stress test
- **Benchmark**: kept with clearer formatting

## TypeScript changes (`index.d.ts`)

- JSDoc annotations for every method and parameter
- Explicit readonly properties (`width`, `height`, `depth`, `buffer`, `pindex`)
- `ColorArray` typed as tuple `[number, number, number, number?]`
- Node.js Buffer reference via triple-slash directive
- All throw conditions documented in JSDoc @throws tags

## Testing

```
18 passing (83ms)
```
