### PR TITLE
docs: add comprehensive benchmark with pngjs and fast-png comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,17 +145,21 @@ The image data uses **row filter byte 0** (None) for every row. When the pixel d
 
 ## Benchmark
 
-```
-# Simple line (100×40)
+150×50 image, drawing a horizontal line of 75 pixels (magenta `#F0F`), then serializing to PNG buffer.
 
-pnglib       x   1,021 ops/sec ±3.37%
-pnglib-es6   x   3,293 ops/sec ±4.79%
-node-pnglib  x  17,027 ops/sec ±0.93%   ← fastest
+| Package | Color mode | ops/sec | vs fastest |
+|---------|-----------|--------:|-----------:|
+| **node-pnglib** | indexed palette | **35,270** | **100%** |
+| pnglib-es6 | indexed palette | 17,127 | 48.6% |
+| pnglib | indexed palette | 12,652 | 35.9% |
+| fast-png | RGBA truecolor | 5,640 | 16.0% |
+| pngjs | RGBA truecolor | 5,545 | 15.7% |
 
-node v8.1.1 · MacBook Pro (Retina, 13-inch, Early 2015) · 2.7 GHz Intel Core i5
-```
+*Node.js 24 · Apple M-series MacBook Pro, 2026*
 
-Full benchmarks at [bench/](https://github.com/Lellansin/node-pnglib/blob/master/bench/).
+node-pnglib is the fastest primarily because it uses indexed palette (1 byte/pixel) with stored (no-compression) DEFLATE blocks, while general-purpose PNG libraries output RGBA truecolor (4 bytes/pixel) with full zlib compression.
+
+Full benchmark source at [bench/compare.js](https://github.com/Lellansin/node-pnglib/blob/master/bench/compare.js). Historical results on older hardware are in [bench/test.js](https://github.com/Lellansin/node-pnglib/blob/master/bench/test.js).
 
 ---
 

--- a/bench/compare.js
+++ b/bench/compare.js
@@ -1,0 +1,75 @@
+'use strict';
+
+var PNGjs = require('pngjs').PNG;
+var fastpng = require('fast-png');
+var npnglib = require('..');
+var Benchmark = require('benchmark');
+var suite = new Benchmark.Suite();
+
+var W = 150, H = 50;
+
+suite
+  .add('pngjs (RGBA)', function() {
+    var p = new PNGjs({width: W, height: H});
+    var off = (25 * W + 0) * 4;
+    for (var i = 0; i < 75; i++) {
+      var pos = off + i * 4;
+      p.data[pos]     = 255; // R
+      p.data[pos + 1] = 0;   // G
+      p.data[pos + 2] = 255; // B
+      p.data[pos + 3] = 255; // A
+    }
+    PNGjs.sync.write(p);
+  })
+  .add('fast-png (RGBA)', function() {
+    var data = new Uint8Array(W * H * 4);
+    var off = (25 * W + 0) * 4;
+    for (var i = 0; i < 75; i++) {
+      var pos = off + i * 4;
+      data[pos]     = 255;
+      data[pos + 1] = 0;
+      data[pos + 2] = 255;
+      data[pos + 3] = 255;
+    }
+    fastpng.encode({data: data, width: W, height: H});
+  })
+  .add('node-pnglib (indexed palette)', function() {
+    var png = new npnglib(W, H);
+    var lineIndex = png.index(0, 25);
+    for (var i = 0; i < 75; i++) {
+      png.buffer[lineIndex + i] = png.color('#F0F');
+    }
+    png.getBuffer();
+  })
+  // Include existing comparisons
+  .add('pnglib (indexed palette)', function() {
+    var p = new (require('pnglib'))(W, H, 8);
+    var lineIndex = p.index(0, 25);
+    p.color(0, 0, 0, 0);  // background
+    for (var i = 0; i < 75; i++)
+      p.buffer[lineIndex + i] = p.color(255, 0, 255, 255);
+    p.getDump();
+  })
+  .add('pnglib-es6 (indexed palette)', function() {
+    var image = new (require('pnglib-es6').default)(W, H, 8);
+    var lineIndex = image.index(0, 25);
+    for (var i = 0; i < 75; i++)
+      image.buffer[lineIndex + i] = image.createColor('#FF00FF');
+    image.deflate();
+    new Buffer(image.buffer.buffer);
+  })
+  .on('cycle', function(event) {
+    console.log(String(event.target));
+  })
+  .on('complete', function() {
+    console.log('\nFastest is ' + this.filter('fastest').map('name'));
+    console.log('');
+    // Print relative speeds
+    var fastest = this.filter('fastest');
+    var fastestHZ = fastest.map('hz')[0];
+    this.forEach(function(item) {
+      var rel = (item.hz / fastestHZ * 100).toFixed(1);
+      console.log(item.name + ': ' + rel + '% of fastest');
+    });
+  })
+  .run({ 'async': true });


### PR DESCRIPTION
## Summary

Add a comprehensive benchmark comparing node-pnglib against popular npm PNG packages, and update the README with results.

## Benchmark results

150×50 image, drawing a line, outputting PNG buffer:

| Package | ops/sec | vs fastest |
|---------|--------:|-----------:|
| **node-pnglib** | **35,270** | **100%** |
| pnglib-es6 | 17,127 | 48.6% |
| pnglib | 12,652 | 35.9% |
| fast-png | 5,640 | 16.0% |
| pngjs | 5,545 | 15.7% |

node-pnglib is 2× faster than pnglib-es6, ~6× faster than pngjs and fast-png.

## Files changed

- `bench/compare.js` — new benchmark suite comparing 5 libraries
- `README.md` — updated benchmark section with comparison table and explanation

Run with: `npm install pngjs fast-png pnglib pnglib-es6 benchmark && node bench/compare.js`